### PR TITLE
feat: Add support to return the ESXi host and vCenter Server password policy

### DIFF
--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -422,6 +422,152 @@ Function Undo-SddcManagerRole {
 }
 Export-ModuleMember -Function Undo-SddcManagerRole
 
+Function Get-EsxiPasswordPolicy {
+	<#
+        .SYNOPSIS
+        Retrieve ESXi servers' Password Policies
+
+        .DESCRIPTION
+        The Get-EsxiPasswordPolicy cmdlet returns a list contains a list of ESXi
+		hosts with current configured password policy nested within a vcenter cluster.  
+		The cmdlet connects to SDDC Manager using the -server, -user, and -password values:
+        - Validates that network connectivity and authentication is possible to SDDC Manager
+        - Validates that the workload domain exists in the SDDC Manager inventory
+        - Validates that network connectivity and authentication is possible to vCenter Server
+        - Gathers the ESXi hosts for the cluster specificed
+        - Retrieve all ESXi hosts password policies
+
+        .EXAMPLE
+        Get-EsxiPasswordPolicy -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -domain sfo-m01 -cluster sfo-m01-cl0l
+        This example retrieves all ESXi hosts password policies within the cluster named sfo-m01-cl01 of the workload domain sfo-m01
+
+    #>
+	Param(
+		[Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$server,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$user,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$pass,
+		[Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$domain,
+		[Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$cluster
+	)
+	
+	# construct ESXi server Object
+	$esxiPasswdPolicy = New-Object System.Collections.Generic.List[System.Object]
+	
+	Try{
+		if (Test-Connection -server $server) {
+			if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
+				if (Get-VCFWorkloadDomain | Where-Object {$_.name -eq $domain}) {
+					if (($vcfVcenterDetails = Get-vCenterServerDetail -server $server -user $user -pass $pass -domain $domain)) {
+						if (Test-VsphereConnection -server $($vcfVcenterDetails.fqdn)) {
+							if (Test-VsphereAuthentication -server $vcfVcenterDetails.fqdn -user $vcfVcenterDetails.ssoAdmin -pass $vcfVcenterDetails.ssoAdminPass) {
+								if (Get-Cluster | Where-Object {$_.Name -eq $cluster}) {
+									$esxiHosts = Get-Cluster $cluster | Get-VMHost | Sort-Object -Property Name
+									if ($esxiHosts) {
+										Foreach ($esxiHost in $esxiHosts) {
+											# retreving ESXi password policy string
+											$passwordPolicy = Get-VMHost -name $esxiHost | Where-Object { $_.ConnectionState -eq "Connected" -or $_.ConnectionState -eq "Maintenance"} | Get-AdvancedSetting | Where-Object { $_.Name -eq "Security.PasswordQualityControl" }
+											# retreving ESXi password Expiration Period
+											$passwordExpire = Get-VMHost -name $esxiHost | Where-Object { $_.ConnectionState -eq "Connected" -or $_.ConnectionState -eq "Maintenance"} | Get-AdvancedSetting | Where-Object { $_.Name -eq "Security.PasswordMaxDays" }
+											if ($passwordPolicy -and $passwordExpire) {
+												# parsing ESXi password policy string
+												$nodePasswdPolicy = New-Object -TypeName psobject
+												$nodePasswdPolicy | Add-Member -notepropertyname "fqdn" -notepropertyvalue $esxiHost.Name
+												$nodePasswdPolicy | Add-Member -notepropertyname "PaswordMaxDays" -notepropertyvalue $passwordExpire.Value
+												$nodePasswdPolicy | Add-Member -notepropertyname "PasswordQualityControl" -notepropertyvalue $passwordPolicy.Value
+												$esxiPasswdPolicy.Add($nodePasswdPolicy)
+												Remove-Variable -Name nodePasswdPolicy
+											}
+											else {
+												Write-Error "Unable to retrieve password policy from ESXi host '$esxiHost.Name'"
+											}
+										}
+										return $esxiPasswdPolicy
+									}
+									else {
+										Write-Warning "No ESXi hosts found within $cluster cluster."
+									}
+								}
+								else {
+										Write-Error "Cluster $cluster not found in $vcfVcenterDetails.fqdn vCenter Server."
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	Catch{
+		Debug-ExceptionWriter -object $_
+	}
+}
+Export-ModuleMember -Function Get-EsxiPasswordPolicy
+
+Function Get-VCServerPasswordPolicy {
+	<#
+        .SYNOPSIS
+        Retrieve vCenter servers' Password Policy
+
+        .DESCRIPTION
+        The Get-VCServerPasswordPolicy cmdlet returns the current configured password expiration period
+		and the email for warning notification settings for the vCenter Server root account
+        The cmdlet connects to SDDC Manager using the -server, -user, and -password values:
+        - Validates that network connectivity and authentication is possible to SDDC Manager
+        - Validates that network connectivity and authentication is possible to vCenter Server
+		- Retrieve the password expiration period and the email for warning notification settings for the vCenter Server root account
+
+        .EXAMPLE
+        Get-VCServerPasswordPolicy -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -domain sfo-m01
+        This example retrieves the password expiration period and the email for warning notification settings for the vCenter Server root account
+
+    #>
+	Param(
+		[Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$server,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$user,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$pass,
+		[Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$domain
+	)
+
+	Try{
+		if (Test-Connection -server $server) {
+			if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
+				if (Get-VCFWorkloadDomain | Where-Object {$_.name -eq $domain}) {
+					if (($vcfVcenterDetails = Get-vCenterServerDetail -server $server -user $user -pass $pass -domain $domain)) {
+						if (Test-VsphereConnection -server $($vcfVcenterDetails.fqdn)) {
+							if (Test-VsphereAuthentication -server $vcfVcenterDetails.fqdn -user $vcfVcenterDetails.ssoAdmin -pass $vcfVcenterDetails.ssoAdminPass) {
+								Request-vSphereApiToken -Fqdn $vcfVcenterDetails.fqdn -Username $vcfVcenterDetails.ssoAdmin -Password $vcfVcenterDetails.ssoAdminPass -admin | Out-Null
+								$pwdExpirySettings = Get-VCPasswordExpiry
+								if ($pwdExpirySettings){
+									foreach ($configurationString in $pwdExpirySettings.PSObject.Properties) {
+										if ($configurationString.name -eq "email") {
+											$passwdNotifyEmail = $configurationString.value
+										}
+										if ($configurationString.name -eq "max_days_between_password_change") {
+											$passwdExpInDays = $configurationString.value
+										}
+									}
+									$vcPasswdPolicy = New-Object -TypeName psobject
+									$vcPasswdPolicy | Add-Member -notepropertyname "fqdn" -notepropertyvalue $vcfVcenterDetails.fqdn
+									$vcPasswdPolicy | Add-Member -notepropertyname "email" -notepropertyvalue $passwdNotifyEmail
+									$vcPasswdPolicy | Add-Member -notepropertyname "max_days_between_password_change" -notepropertyvalue $passwdExpInDays
+									return $vcPasswdPolicy
+								}
+								else {
+									Write-Error "Unable to retrieve password policy for vCenter server '$server'"
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	Catch{
+		Debug-ExceptionWriter -object $_
+	}
+}
+Export-ModuleMember -Function Get-VCServerPasswordPolicy
+
 Function Set-vCenterPasswordExpiration {
     <#
 		.SYNOPSIS

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -425,11 +425,11 @@ Export-ModuleMember -Function Undo-SddcManagerRole
 Function Get-EsxiPasswordPolicy {
 	<#
         .SYNOPSIS
-        Retrieve ESXi servers' Password Policies
+        Retrieves ESXi Host Password Policies
 
         .DESCRIPTION
-        The Get-EsxiPasswordPolicy cmdlet returns a list contains a list of ESXi
-		hosts with current configured password policy nested within a vcenter cluster.  
+        The Get-EsxiPasswordPolicy cmdlet retrieves a list of ESXi hosts displaying the currently
+        configured password policy nested within a vSphere cluster  
 		The cmdlet connects to SDDC Manager using the -server, -user, and -password values:
         - Validates that network connectivity and authentication is possible to SDDC Manager
         - Validates that the workload domain exists in the SDDC Manager inventory
@@ -439,10 +439,10 @@ Function Get-EsxiPasswordPolicy {
 
         .EXAMPLE
         Get-EsxiPasswordPolicy -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -domain sfo-m01 -cluster sfo-m01-cl0l
-        This example retrieves all ESXi hosts password policies within the cluster named sfo-m01-cl01 of the workload domain sfo-m01
+        This example retrieves all ESXi hosts password policies within the cluster named sfo-m01-cl01 for the workload domain sfo-m01
 
     #>
-	Param(
+	Param (
 		[Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$server,
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$user,
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$pass,
@@ -450,10 +450,10 @@ Function Get-EsxiPasswordPolicy {
 		[Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$cluster
 	)
 	
-	# construct ESXi server Object
+	# Create the ESXi Host object
 	$esxiPasswdPolicy = New-Object System.Collections.Generic.List[System.Object]
 	
-	Try{
+	Try {
 		if (Test-Connection -server $server) {
 			if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
 				if (Get-VCFWorkloadDomain | Where-Object {$_.name -eq $domain}) {
@@ -488,16 +488,19 @@ Function Get-EsxiPasswordPolicy {
 									}
 								}
 								else {
-										Write-Error "Cluster $cluster not found in $vcfVcenterDetails.fqdn vCenter Server."
+										Write-Error "Unable to locate Cluster $cluster in $vcfVcenterDetails.fqdn vCenter Server: PRE_VALIDATION_FAILED"
 								}
 							}
 						}
 					}
 				}
+                else {
+                    Write-Error "Unable to locate workload domain $domain in $server SDDC Manager Server: PRE_VALIDATION_FAILED"
+                }
 			}
 		}
 	}
-	Catch{
+	Catch {
 		Debug-ExceptionWriter -object $_
 	}
 }
@@ -506,29 +509,29 @@ Export-ModuleMember -Function Get-EsxiPasswordPolicy
 Function Get-VCServerPasswordPolicy {
 	<#
         .SYNOPSIS
-        Retrieve vCenter servers' Password Policy
+        Retrieves a vCenter servers' Password Policies
 
         .DESCRIPTION
-        The Get-VCServerPasswordPolicy cmdlet returns the current configured password expiration period
+        The Get-VCServerPasswordPolicy cmdlet returns the currently configured password expiration period
 		and the email for warning notification settings for the vCenter Server root account
         The cmdlet connects to SDDC Manager using the -server, -user, and -password values:
         - Validates that network connectivity and authentication is possible to SDDC Manager
         - Validates that network connectivity and authentication is possible to vCenter Server
-		- Retrieve the password expiration period and the email for warning notification settings for the vCenter Server root account
+		- Retrieves the password expiration period and the email for warning notification settings for the vCenter Server root account
 
         .EXAMPLE
         Get-VCServerPasswordPolicy -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -domain sfo-m01
         This example retrieves the password expiration period and the email for warning notification settings for the vCenter Server root account
 
     #>
-	Param(
+	Param (
 		[Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$server,
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$user,
         [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$pass,
 		[Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$domain
 	)
 
-	Try{
+	Try {
 		if (Test-Connection -server $server) {
 			if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
 				if (Get-VCFWorkloadDomain | Where-Object {$_.name -eq $domain}) {
@@ -559,6 +562,9 @@ Function Get-VCServerPasswordPolicy {
 						}
 					}
 				}
+                else {
+                    Write-Error "Unable to locate workload domain $domain in $server SDDC Manager Server: PRE_VALIDATION_FAILED"
+                }
 			}
 		}
 	}


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/power-validated-solutions-for-cloud-foundation/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Add 2 cmdlets
- `Get-ESXiPasswordPolicy`
- `Get-VCServerPasswordPolicy`

This cmdlets are used return the password expiration policy for an ESXi host and vCenter Server instance in number of days.

Signed-off-by: Kevin Teng <kteng@vmware.com>

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [x] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: #31 

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
