### PR TITLE
refactor: update errors for `Add-SupervisorClusterLicense`

### DIFF
--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -9044,11 +9044,17 @@ Function Add-SupervisorClusterLicense {
                                                     Start-Sleep 10
                                                 } while ($taskStatus -eq "In Progress")
                                                 if ($taskStatus -eq "Successful") {
-                                                    Write-Output "Assign license key ($licenseKey) to Supervisior cluster ($cluster) : SUCCESSFUL"
+                                                    Write-Output "Assign license key ($licenseKey) to Supervisior cluster ($cluster): SUCCESSFUL"
                                                 }
                                                 else {
-                                                    Write-Error "Assign license key ($licenseKey) to Supervisior cluster ($cluster) : FAILED"
-                                                    break
+                                                    $PSCmdlet.ThrowTerminatingError(
+                                                        [System.Management.Automation.ErrorRecord]::new(
+                                                            ([System.Management.Automation.GetValueException]"Unable to validate license key ($licenseKey) was properly added to Supervisor Cluster ($cluster): POST_VALIDATION_FAILED"),
+                                                            'Add-SupervisorClusterLicense',
+                                                            [System.Management.Automation.ErrorCategory]::InvalidResult,
+                                                            ""
+                                                        )
+                                                    )
                                                 } 
                                             }
                                             Catch {
@@ -9056,11 +9062,17 @@ Function Add-SupervisorClusterLicense {
                                             }
                                         }
                                         else {
-                                            Write-Error "Adding license key ($licenseKey) in SDDC manager ($sddcManager): POST_VALIDATION_FAILED"
-                                            break
+                                            $PSCmdlet.ThrowTerminatingError(
+                                                [System.Management.Automation.ErrorRecord]::new(
+                                                    ([System.Management.Automation.GetValueException]"Unable to validate license key ($licenseKey) was properly added to Supervisor Cluster ($cluster): POST_VALIDATION_FAILED"),
+                                                    'Add-SupervisorClusterLicense',
+                                                    [System.Management.Automation.ErrorCategory]::InvalidResult,
+                                                    ""
+                                                )
+                                            )
                                         }
                                     } else {
-                                        Write-Warning "Adding license key ($licenseKey) in SDDC manager ($sddcManager), already exists: SKIPPED"
+                                        Write-Warning "License key ($licenseKey) already exists in SDDC manager ($sddcManager) inventory: SKIPPED"
                                     }
                                     
                                 }
@@ -9068,12 +9080,26 @@ Function Add-SupervisorClusterLicense {
                             }
                         }
                         else {
-                            Write-Error "Unable to find cluster named ($cluster) in the Workload Domain named ($domain) in the invenotry of SDDC Manager ($server): PRE_VALIDATION_FAILED"
+                            $PSCmdlet.ThrowTerminatingError(
+                                [System.Management.Automation.ErrorRecord]::new(
+                                    ([System.Management.Automation.ItemNotFoundException]"Unable to find cluster named ($cluster) in the Workload Domain named ($domain) in the invenotry of SDDC Manager ($server): PRE_VALIDATION_FAILED"),
+                                    'Add-SupervisorClusterLicense',
+                                    [System.Management.Automation.ErrorCategory]::ObjectNotFound,
+                                    ""
+                                )
+                            )
                         }
                     }
                 }
                 else {
-                    Write-Error "Unable to find Workload Domain named ($domain) in the inventory of SDDC Manager ($server): PRE_VALIDATION_FAILED"
+                    $PSCmdlet.ThrowTerminatingError(
+                        [System.Management.Automation.ErrorRecord]::new(
+                            ([System.Management.Automation.ItemNotFoundException]"Unable to find Workload Domain named ($domain) in the inventory of SDDC Manager ($server): PRE_VALIDATION_FAILED"),
+                            'Add-SupervisorClusterLicense',
+                            [System.Management.Automation.ErrorCategory]::ObjectNotFound,
+                            ""
+                        )
+                    )
                 }
             }
         }


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/power-validated-solutions-for-cloud-foundation/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

This PR adds more detailed error messages for Add-SupervisorClusterLicense.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [x] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

For `Add-SupervisorClusterLicense`: changed `Write-Error` + `break` for script halting errors to use the PowerShell native `$PSCmdlet.ThrowTerminatingError()` method along with additional context added for each specific error message.

**Related to Existing Issues**

None

Issue Number: N/A

**Test and Documentation Coverage**

None

- [x] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.
