### PR TITLE
feat: enable vrli log configuration in vra

### DIFF
--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -10554,7 +10554,7 @@ Function Get-vRAvRLIConfig {
             if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
                 if (($vcfVcenterDetails = Get-vCenterServerDetail -server $server -user $user -pass $pass -domainType MANAGEMENT)) {
                     if (Test-VsphereConnection -server $($vcfVcenterDetails.fqdn)) {
-                      if (Test-VsphereAuthentication -server $vcfVcenterDetails.fqdn -user $vcfVcenterDetails.ssoAdmin -pass $vcfVcenterDetails.ssoAdminPass) {
+                        if (Test-VsphereAuthentication -server $vcfVcenterDetails.fqdn -user $vcfVcenterDetails.ssoAdmin -pass $vcfVcenterDetails.ssoAdminPass) {
                             if ($vraDetails = Get-vRAServerDetail -fqdn $server -username $user -password $pass -ErrorAction Stop) {
                                 if (Test-vRAConnection -server $vRADetails.node1IpAddress) {   
                                     $vmName = $vraDetails.fqdn | Select-Object -First 1
@@ -10563,7 +10563,7 @@ Function Get-vRAvRLIConfig {
                                         $scriptCommand = "vracli vrli"
                                         $output = Invoke-VMScript -VM $vmName -ScriptText $scriptCommand -GuestUser root -GuestPassword $rootPass -Server $vcfVcenterDetails.fqdn
                                         if (($output.ScriptOutput).Contains('No vRLI integration configured')) {
-                                            Write-Output "vRealize Automation integration with vRealize Log Insight not set: SKIPPED"
+                                            Write-Output "vRealize Automation integration with vRealize Log Insight status 'Not Configured'"
                                         } elseif (($output.ScriptOutput).Contains('agentId')) {
                                             $output.ScriptOutput
                                         } else {
@@ -10602,7 +10602,7 @@ Function Set-vRAvRLIConfig {
 
         .EXAMPLE
         Set-vRAvRLIConfig -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -rootPass VMw@re1!
-        This example sets the vRealize Log Insight logging configuration on vRealize Automation to vRealize Log Insight.
+        This example sets the vRealize Log Insight logging configuration on vRealize Automation.
     #>
 
     Param (
@@ -10658,15 +10658,12 @@ Function Set-vRAvRLIConfig {
                                                     $status = Get-vRAvRLIConfig -server $server -user $user -pass $pass -rootPass $rootPass      
                                                     if (($status).Contains("`"host`": `"$uriHost`"")) -and (($status).Contains("`"port`": $uriPort")) -and (($status).Contains("`"scheme`": `"$uriProtocol`"")) {
                                                         Write-Output 'Setting the vRealize Automation integration with vRealize Log Insight: SUCCESSFUL'
-                                                    }
-                                                    elseif (($status).Contains('No vRLI integration configured')) {
-                                                        Write-Output 'vRealize Automation integration with vRealize Log Insight configuration not set: SKIPPED'
-                                                    }
-                                                    else {
+                                                    } elseif (($status).Contains('No vRLI integration configured')) {
+                                                        Write-Warning 'vRealize Automation integration with vRealize Log Insight configuration not set: SKIPPED'
+                                                    } else {
                                                         Write-Error 'Setting the vRealize Automation integration with vRealize Log Insight: POST_VALIDATION_FAILED'
                                                     }
-                                                }
-                                                else {
+                                                } else {
                                                     Write-Error "Unable to locate a virtual machine named ($vmName) in vCenter Server ($($vcfVcenterDetails.fqdn)) inventory: PRE_VALIDATION_FAILED"                                        
                                                 }
                                             }
@@ -10729,9 +10726,9 @@ Function Remove-vRAvRLIConfig {
                                         if (($output.ScriptOutput).Contains('Clearing vRLI integration configuration')) {
                                             Write-Output "Clearing the vRealize Automation integration with vRealize Log Insight: SUCCESSFUL"
                                         } elseif (($output.ScriptOutput).Contains('No vRLI integration configured')) {
-                                            Write-Output "vRealize Automation integration with vRealize Log Insight not set: SKIPPED"
+                                            Write-Warning "vRealize Automation integration with vRealize Log Insight not set: SKIPPED"
                                         } else {
-                                            Write-Error "Clearing the vRealize Automation integration with vRealize Log Insight: POST_VALIDATION_FAILED"
+                                            Write-Warning "Clearing the vRealize Automation integration with vRealize Log Insight: POST_VALIDATION_FAILED"
                                         }
                                     } else {
                                         Write-Error "Unable to locate a virtual machine named ($vmName) in vCenter Server ($($vcfVcenterDetails.fqdn)) inventory: PRE_VALIDATION_FAILED"                                        

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -10528,10 +10528,9 @@ Function Get-vRAvRLIConfig {
         Returns the vRealize Log Insight logging configuration (CFAPI) on vRealize Automation.
 
         .DESCRIPTION
-        The Get-vRAvRLIConfig cmdlet returns the vRealize Log Insight logging
-        configuration for vRealize Automation.
-        The cmdlet connects to SDDC Manager using the -server, -user, and -password values and
-        connects to the first vRealize Automation appliance using the -rootPass value.
+        The Get-vRAvRLIConfig cmdlet returns the vRealize Log Insight logging configuration for vRealize Automation.
+        The cmdlet connects to SDDC Manager using the -server, -user, and -password values and connects to the first
+        vRealize Automation appliance using the -rootPass value.
         - Validates that network connectivity and authentication is possible to SDDC Manager
         - Validates that network connectivity and authentication is possible to Management Domain vCenter Server
         - Validates that network connectivity is possible to the first vRealize Automation appliance
@@ -10592,8 +10591,8 @@ Function Set-vRAvRLIConfig {
 
         .DESCRIPTION
         The Set-vRAvRLIConfig cmdlet sets the vRealize Log Insight logging configuration for vRealize Automation.
-        The cmdlet connects to SDDC Manager using the -server, -user, and -password values and connects to the
-        first vRealize Automation appliance using the -rootPass value.
+        The cmdlet connects to SDDC Manager using the -server, -user, and -password values and connects to the first
+        vRealize Automation appliance using the -rootPass value.
         - Validates that network connectivity and authentication is possible to SDDC Manager
         - Validates that network connectivity and authentication is possible to Management Domain vCenter Server
         - Validates that network connectivity and authentication is possible to vRealize Log Insight
@@ -10689,10 +10688,9 @@ Function Remove-vRAvRLIConfig {
         Removes the vRealize Log Insight logging configuration (CFAPI) on vRealize Automation.
 
         .DESCRIPTION
-        The Remove-vRAvRLIConfig cmdlet removes the vRealize Log Insight logging
-        configuration for vRealize Automation.
-        The cmdlet connects to SDDC Manager using the -server, -user, and -password values and
-        connects to the first vRealize Automation appliance using the -rootPass value.
+        The Remove-vRAvRLIConfig cmdlet removes the vRealize Log Insight logging configuration for vRealize Automation.
+        The cmdlet connects to SDDC Manager using the -server, -user, and -password values and connects to the first
+        vRealize Automation appliance using the -rootPass value.
         - Validates that network connectivity and authentication is possible to SDDC Manager
         - Validates that network connectivity and authentication is possible to Management Domain vCenter Server
         - Validates that network connectivity is possible to the first vRealize Automation appliance

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -10522,6 +10522,233 @@ Function Undo-NsxtNodeProfileSyslogExporter {
 }
 Export-ModuleMember -Function Undo-NsxtNodeProfileSyslogExporter
 
+Function Get-vRAvRLIConfig {
+    <#
+		.SYNOPSIS
+        Returns the vRealize Log Insight logging configuration (CFAPI) on vRealize Automation.
+
+        .DESCRIPTION
+        The Get-vRAvRLIConfig cmdlet returns the vRealize Log Insight logging
+        configuration for vRealize Automation.
+        The cmdlet connects to SDDC Manager using the -server, -user, and -password values and
+        connects to the first vRealize Automation appliance using the -rootPass value.
+        - Validates that network connectivity and authentication is possible to SDDC Manager
+        - Validates that network connectivity and authentication is possible to Management Domain vCenter Server
+        - Validates that network connectivity is possible to the first vRealize Automation appliance
+        - Returns the vRealize Log Insight configuration in vRealize Automation
+
+        .EXAMPLE
+        Get-vRAvRLIConfig -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -rootPass VMw@re1!
+        This example returns the vRealize Log Insight logging configuration on vRealize Automation.
+    #>
+
+    Param (
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$server,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$user,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$pass,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$rootPass
+    )
+
+    Try {
+        if (Test-VCFConnection -server $server) {
+            if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
+                if (($vcfVcenterDetails = Get-vCenterServerDetail -server $server -user $user -pass $pass -domainType MANAGEMENT)) {
+                    if (Test-VsphereConnection -server $($vcfVcenterDetails.fqdn)) {
+                      if (Test-VsphereAuthentication -server $vcfVcenterDetails.fqdn -user $vcfVcenterDetails.ssoAdmin -pass $vcfVcenterDetails.ssoAdminPass) {
+                            if ($vraDetails = Get-vRAServerDetail -fqdn $server -username $user -password $pass -ErrorAction Stop) {
+                                if (Test-vRAConnection -server $vRADetails.node1IpAddress) {   
+                                    $vmName = $vraDetails.fqdn | Select-Object -First 1
+                                    $vmName = $vmName.Split(".")[0]
+                                    if ((Get-VM -Name $vmName -WarningAction SilentlyContinue -ErrorAction SilentlyContinue )) {
+                                        $scriptCommand = "vracli vrli"
+                                        $output = Invoke-VMScript -VM $vmName -ScriptText $scriptCommand -GuestUser root -GuestPassword $rootPass -Server $vcfVcenterDetails.fqdn
+                                        if (($output.ScriptOutput).Contains('No vRLI integration configured')) {
+                                            Write-Output "vRealize Automation integration with vRealize Log Insight not set: SKIPPED"
+                                        } elseif (($output.ScriptOutput).Contains('agentId')) {
+                                            $output.ScriptOutput
+                                        } else {
+                                            Write-Error "Returning the vRealize Automation integration with vRealize Log Insight: POST_VALIDATION_FAILED"
+                                        }
+                                    } else {
+                                        Write-Error "Unable to locate a virtual machine named ($vmName) in vCenter Server ($($vcfVcenterDetails.fqdn)) inventory: PRE_VALIDATION_FAILED"                                        
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    } Catch {
+        Debug-ExceptionWriter -object $_
+    }
+}
+Export-ModuleMember -Function Get-vRAvRLIConfig
+
+Function Set-vRAvRLIConfig {
+    <#
+		.SYNOPSIS
+        Sets the vRealize Log Insight logging configuration (CFAPI) on vRealize Automation.
+
+        .DESCRIPTION
+        The Set-vRAvRLIConfig cmdlet sets the vRealize Log Insight logging configuration for vRealize Automation.
+        The cmdlet connects to SDDC Manager using the -server, -user, and -password values and connects to the
+        first vRealize Automation appliance using the -rootPass value.
+        - Validates that network connectivity and authentication is possible to SDDC Manager
+        - Validates that network connectivity and authentication is possible to Management Domain vCenter Server
+        - Validates that network connectivity and authentication is possible to vRealize Log Insight
+        - Validates that network connectivity is possible to the first vRealize Automation appliance
+        - Sets the vRealize Log Insight configuration on vRealize Automation
+
+        .EXAMPLE
+        Set-vRAvRLIConfig -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -rootPass VMw@re1!
+        This example sets the vRealize Log Insight logging configuration on vRealize Automation to vRealize Log Insight.
+    #>
+
+    Param (
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$server,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$user,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$pass,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$rootPass,
+        [Parameter (Mandatory = $true)] [ValidateSet("HTTPS", "HTTP")] [String]$protocol,
+        [Parameter (Mandatory = $false)] [ValidateNotNullOrEmpty()] [Int]$port
+    )
+
+    Try {
+        if (Test-VCFConnection -server $server) {
+            if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
+                if (($vcfVcenterDetails = Get-vCenterServerDetail -server $server -user $user -pass $pass -domainType MANAGEMENT)) {
+                    if (Test-VsphereConnection -server $($vcfVcenterDetails.fqdn)) {
+                        if (Test-VsphereAuthentication -server $vcfVcenterDetails.fqdn -user $vcfVcenterDetails.ssoAdmin -pass $vcfVcenterDetails.ssoAdminPass) {
+                            if ($vraDetails = Get-vRAServerDetail -fqdn $server -username $user -password $pass -ErrorAction Stop) {
+                                if (Test-vRAConnection -server $vRADetails.node1IpAddress) {
+                                    if (($vcfVrliDetails = Get-vRLIServerDetail -fqdn $server -username $user -password $pass)) {
+                                        if (Test-vRLIConnection -server $vcfVrliDetails.fqdn) {
+                                            if (Test-vRLIAuthentication -server $vcfVrliDetails.fqdn -user $vcfVrliDetails.adminUser -pass $vcfVrliDetails.adminPass) {
+                                                $vmName = $vraDetails.fqdn | Select-Object -First 1
+                                                $vmName = $vmName.Split('.')[0]
+                                                if ((Get-VM -Name $vmName -WarningAction SilentlyContinue -ErrorAction SilentlyContinue )) {
+
+                                                    # Set the uri format and default ports
+                                                    if ($protocol -eq "HTTPS") {
+                                                        $uriProtocol = $protocol.ToLower()
+                                                        $uriPort = 9543 # CFAPI SSL Default
+                                                    } elseif ($protocol -eq "HTTP") {
+                                                        $uriProtocol = $protocol.ToLower()
+                                                        $uriPort = 9000 # CFAPI Non-SSL Default
+                                                    }
+
+                                                    # Set the port if provided
+                                                    if ($PsBoundParameters.ContainsKey("port")) {
+                                                        $uriPort = $port
+                                                    }
+
+                                                    # Set the uri to the vRealize Log Insight cluster FQDN
+                                                    $uriHost = $vcfVrliDetails.fqdn
+
+                                                    # Run commands based on the selected protocol
+                                                    if ($protocol -eq "HTTPS") {
+                                                        $scriptCommand = "vracli vrli set " + $uriProtocol + "://" + $uriHost + ":" + $uriPort + " --force" # Must use --force to accept certificate.
+                                                        $output = Invoke-VMScript -VM $vmName -ScriptText $scriptCommand -GuestUser root -GuestPassword $rootPass -Server $vcfVcenterDetails.fqdn
+                                                    } else {
+                                                        $scriptCommand = 'vracli vrli set ' + $uriProtocol + '://' + $uriHost + ':' + $uriPort
+                                                        $output = Invoke-VMScript -VM $vmName -ScriptText $scriptCommand -GuestUser root -GuestPassword $rootPass -Server $vcfVcenterDetails.fqdn
+                                                    }
+
+                                                    $status = Get-vRAvRLIConfig -server $server -user $user -pass $pass -rootPass $rootPass      
+                                                    if (($status).Contains("`"host`": `"$uriHost`"")) -and (($status).Contains("`"port`": $uriPort")) -and (($status).Contains("`"scheme`": `"$uriProtocol`"")) {
+                                                        Write-Output 'Setting the vRealize Automation integration with vRealize Log Insight: SUCCESSFUL'
+                                                    }
+                                                    elseif (($status).Contains('No vRLI integration configured')) {
+                                                        Write-Output 'vRealize Automation integration with vRealize Log Insight configuration not set: SKIPPED'
+                                                    }
+                                                    else {
+                                                        Write-Error 'Setting the vRealize Automation integration with vRealize Log Insight: POST_VALIDATION_FAILED'
+                                                    }
+                                                }
+                                                else {
+                                                    Write-Error "Unable to locate a virtual machine named ($vmName) in vCenter Server ($($vcfVcenterDetails.fqdn)) inventory: PRE_VALIDATION_FAILED"                                        
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Catch {
+        Debug-ExceptionWriter -object $_
+    }
+}
+Export-ModuleMember -Function Set-vRAvRLIConfig
+
+Function Remove-vRAvRLIConfig {
+    <#
+		.SYNOPSIS
+        Removes the vRealize Log Insight logging configuration (CFAPI) on vRealize Automation.
+
+        .DESCRIPTION
+        The Remove-vRAvRLIConfig cmdlet removes the vRealize Log Insight logging
+        configuration for vRealize Automation.
+        The cmdlet connects to SDDC Manager using the -server, -user, and -password values and
+        connects to the first vRealize Automation appliance using the -rootPass value.
+        - Validates that network connectivity and authentication is possible to SDDC Manager
+        - Validates that network connectivity and authentication is possible to Management Domain vCenter Server
+        - Validates that network connectivity is possible to the first vRealize Automation appliance
+        - Unsets the vRealize Log Insight configuration in vRealize Automation
+
+        .EXAMPLE
+        Remove-vRAvRLIConfig -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -rootPass VMw@re1!
+        This example removes the vRealize Log Insight logging configuration on vRealize Automation.
+    #>
+
+    Param (
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$server,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$user,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$pass,
+        [Parameter (Mandatory = $true)] [ValidateNotNullOrEmpty()] [String]$rootPass
+    )
+
+    Try {
+        if (Test-VCFConnection -server $server) {
+            if (Test-VCFAuthentication -server $server -user $user -pass $pass) {
+                if (($vcfVcenterDetails = Get-vCenterServerDetail -server $server -user $user -pass $pass -domainType MANAGEMENT)) {
+                    if (Test-VsphereConnection -server $($vcfVcenterDetails.fqdn)) {
+                      if (Test-VsphereAuthentication -server $vcfVcenterDetails.fqdn -user $vcfVcenterDetails.ssoAdmin -pass $vcfVcenterDetails.ssoAdminPass) {
+                            if ($vraDetails = Get-vRAServerDetail -fqdn $server -username $user -password $pass -ErrorAction Stop) {
+                                if (Test-vRAConnection -server $vRADetails.node1IpAddress) {   
+                                    $vmName = $vraDetails.fqdn | Select-Object -First 1
+                                    $vmName = $vmName.Split(".")[0]
+                                    if ((Get-VM -Name $vmName -WarningAction SilentlyContinue -ErrorAction SilentlyContinue )) {
+                                        $scriptCommand = "vracli vrli unset"
+                                        $output = Invoke-VMScript -VM $vmName -ScriptText $scriptCommand -GuestUser root -GuestPassword $rootPass -Server $vcfVcenterDetails.fqdn
+                                        if (($output.ScriptOutput).Contains('Clearing vRLI integration configuration')) {
+                                            Write-Output "Clearing the vRealize Automation integration with vRealize Log Insight: SUCCESSFUL"
+                                        } elseif (($output.ScriptOutput).Contains('No vRLI integration configured')) {
+                                            Write-Output "vRealize Automation integration with vRealize Log Insight not set: SKIPPED"
+                                        } else {
+                                            Write-Error "Clearing the vRealize Automation integration with vRealize Log Insight: POST_VALIDATION_FAILED"
+                                        }
+                                    } else {
+                                        Write-Error "Unable to locate a virtual machine named ($vmName) in vCenter Server ($($vcfVcenterDetails.fqdn)) inventory: PRE_VALIDATION_FAILED"                                        
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    } Catch {
+        Debug-ExceptionWriter -object $_
+    }
+}
+Export-ModuleMember -Function Remove-vRAvRLIConfig
+
 #EndRegion                                 E N D  O F  F U N C T I O N S                                    ###########
 #######################################################################################################################
 


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/power-validated-solutions-for-cloud-foundation/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

Adds three cmdlets for managing the basic configuration of vRealize Automation's integration with vRealize Log Insight.

- `Get-vRAvRLIConfig`
- `Set-vRAvRLIConfig`
- `Remove-vRAvRLIConfig`

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

```powershell
PS F:\> Set-vRAvRLIConfig -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -rootPass VMw@re1! -protocol HTTP
Setting the vRealize Automation integration with vRealize Log Insight: SUCCESSFUL

PS F:\> Set-vRAvRLIConfig -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -rootPass VMw@re1! -protocol HTTPS
Setting the vRealize Automation integration with vRealize Log Insight: SUCCESSFUL

PS F:\> Get-vRAvRLIConfig -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -rootPass VMw@re1!
{
    "agentId": "0",
    "bufferFlushThreadCount": 16,
    "environment": "prod",
    "host": "sfo-vrli01.sfo.rainpole.io",
    "port": 9543,
    "requestHttpCompress": false,
    "requestImmediateRetries": 3,
    "requestMaxSize": 256000,
    "requestTimeout": 30,
    "scheme": "https",
    "sslVerify": true,
    "caFile": "-----BEGIN CERTIFICATE-----\nMIIGMDCCBRigAwIBAgITdAAAAF0EtgQH789HRgAAAAAAXTANBgkqhkiG9w0BAQsF\nADBNMRIwEAYKCZImiZPyLGQBGRYCaW8xGDAWBgoJkiaJk
EdMBsGA1UEAxMUcmFpbnBvbGUtREMtUlBMMDEtQ0EwHhcNMjEwMzAzMTY0MDA5\nWhcNMjMwMzAzMTY1MDA5WjB3MQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExDDAK\nBgNVBAcTA1NGTzEVMBMGA1UEC
DwYDVQQLEwhSYWlu\ncG9sZTEjMCEGA1UEAxMac2ZvLXZybGkwMS5zZm8ucmFpbnBvbGUuaW8wggEiMA0G\nCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCz9ekA/PzH68c6vAv8x9ZPT6fF3Mwo\nDeLyU
y5mWH+pWJ7WkI/Op19eaN7WRfMenPXThnF99\nuaIT4aEn27RRT2vh/WuMHYYnk6NhTTaHw2aAenbVAcNN8EX+S0xIFLNXgKHfkEU6\n8zMmkDT9157UsepcrwL44t68TT0NZzGceHJver6eqioaUAbljXr
yqT+veYsE0aUzDgVlmVON5qbIu0MhXnY8dUPbrEpFthoGGSMp06k9rP4\nLil8XqTP+gkyWfFBxoGhrUmIEX5lelYPProrr4oHFq6W6gIp1Ha0zDgHAgMBAAGj\nggLdMIIC2TAMBgNVHRMBAf8EAjAAMA4
NVHSUEFjAU\nBggrBgEFBQcDAQYIKwYBBQUHAwIwfAYDVR0RBHUwc4Iac2ZvLXZybGkwMS5zZm8u\ncmFpbnBvbGUuaW+CG3Nmby12cmxpMDFhLnNmby5yYWlucG9sZS5pb4Ibc2ZvLXZy\nbGkwMWIuc2Z
8tdnJsaTAxYy5zZm8ucmFpbnBvbGUu\naW8wHQYDVR0OBBYEFGTdkvQE0NZZeh2/ZKHhPDp3UoG8MB8GA1UdIwQYMBaAFJN+\nuOiGhuJAl/KRAYwhMky8j2BVMIHTBgNVHR8EgcswgcgwgcWggcKggb+Gg
5wb2xlLURDLVJQTDAxLUNBLENOPWRjLXJwbDAxLENOPUNEUCxD\nTj1QdWJsaWMlMjBLZXklMjBTZXJ2aWNlcyxDTj1TZXJ2aWNlcyxDTj1Db25maWd1\ncmF0aW9uLERDPXJhaW5wb2xlLERDPWlvP2Nlc
bkxp\nc3Q/YmFzZT9vYmplY3RDbGFzcz1jUkxEaXN0cmlidXRpb25Qb2ludDCBxgYIKwYB\nBQUHAQEEgbkwgbYwgbMGCCsGAQUFBzAChoGmbGRhcDovLy9DTj1yYWlucG9sZS1E\nQy1SUEwwMS1DQSxDT
S2V5JTIwU2VydmljZXMsQ049\nU2VydmljZXMsQ049Q29uZmlndXJhdGlvbixEQz1yYWlucG9sZSxEQz1pbz9jQUNl\ncnRpZmljYXRlP2Jhc2U/b2JqZWN0Q2xhc3M9Y2VydGlmaWNhdGlvbkF1dGhvcml
MDAuBiYrBgEEAYI3FQiF+9Y2g9egXIO5iSeHqqU/gdyC\nJ4Fdnc09h+6ACAIBZAIBBTANBgkqhkiG9w0BAQsFAAOCAQEAR/+cEkwez3UYSR3I\nf913hWdZd26y2bN3/hs6So4+P2ZoFTMEZFqwOP4l58F
Rqb0Og4heAnCY1FPgtdRMT19w9raeTSaJxH6gqG1Fj6A1MjmGfPGQDQ3CzkI09ji\nV9SJbrt+JZy/Atw9sQAkSmmNmSYKJ2e6W9eLlguu2J/9WTOP1BnFOcuFwuAhIguI\nuhnqr6L30+5AOgXChFMJ3a4
CBTjebKW1NBmE2RH7w\nPNAZPcZH7pbseuh5SmUP1SQD1NapcTDP3dT26Ebxbus/7wcAZ2/KfzgG/5lH8YxS\ndY2XLw==\n-----END CERTIFICATE-----\n\n-----BEGIN CERTIFICATE-----\nM
nuZve4hP4M0684rE+TANBgkqhkiG9w0BAQsFADBN\nMRIwEAYKCZImiZPyLGQBGRYCaW8xGDAWBgoJkiaJk/IsZAEZFghyYWlucG9sZTEd\nMBsGA1UEAxMUcmFpbnBvbGUtREMtUlBMMDEtQ0EwHhcNMjA
MjE3MTIxNjQyWjBNMRIwEAYKCZImiZPyLGQBGRYCaW8xGDAWBgoJkiaJk/Is\nZAEZFghyYWlucG9sZTEdMBsGA1UEAxMUcmFpbnBvbGUtREMtUlBMMDEtQ0EwggEi\nMA0GCSqGSIb3DQEBAQUAA4IBDwA
WyUYMwoq6IXjlQ\n0FI0OSO+5bIk0g10mwSxYk9fcgQEgyjirBiW6zRXGuPt6KfhpFaG7N6nQNJAs50s\nwMe7sHCRElWrfb/B0p2I07I4389L28i7pbvTGTSPu6EqvFys8EtpHZ4TPRH7k4Da\nZA7msQU
hL9/qhcthCd0D3QlrX4x7QwzjuZywgQpHt\nOwNeW2gKv7GgWUpi/x5ilQln+X+mUAbIc4ZBUb3596Dual516EQtxD98BZlSFNeh\n2g4PJdvTotuABRTqfXiK5G/AHX8hiG39QuvVC+kL17cfBi/sYIOPa
sGA1UdDwQEAwIBhjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBST\nfrjohobiQJfykQGMITJMvI9gVTAQBgkrBgEEAYI3FQEEAwIBADANBgkqhkiG9w0B\nAQsFAAOCAQEABZOX6PSRhsjqF+DQnelSa
n+t0dNcN\n3mjjL28QmVE8ErA2GirjZXAN3WVaVgRJwrXMVFl50VW7WKlU4BPeJFJm4ycxo4w9\n2nmy1OaGMyGRjS6H/Du77BV/DsthKMuPsJeyrshc/wrJtHLe6NgWLDy2cUr2WrKL\ntfQ5ynUHW+xg7
0N59qG7hlJO91gABVfWduKCkTc0O\n4kFt76oexOkYaMZP4F4hysKoeW8fBY3DtYdUPt//IcJX7S1uG/Zjo1PxBQDV1k1S\nwjdE+PK6bsFUYBjiGM4cJ1/Lzshysq1hvg==\n-----END CERTIFICATE-
}

PS F:\> Remove-vRAvRLIConfig -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -rootPass VMw@re1!
Clearing the vRealize Automation integration with vRealize Log Insight: SUCCESSFUL

PS F:\> Get-vRAvRLIConfig -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -rootPass VMw@re1!
vRealize Automation integration with vRealize Log Insight not set: SKIPPED

```

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [x] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number:  Closes #47

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Tests have been completed (for bug fixes / features).
- [x] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
