### PR TITLE
ci(module): add basic module ci

### DIFF
--- a/.ci/pester.tests.ps1
+++ b/.ci/pester.tests.ps1
@@ -1,0 +1,18 @@
+$moduleName = "PowerValidatedSolutions"
+
+BeforeAll {
+    Import-Module -Name "$PSScriptRoot/../$moduleName.psd1" -Force -ErrorAction Stop
+}
+
+Describe -Tag:('ModuleValidation') 'Module Baseline Validation' {
+
+    It 'is present' {
+        $module = Get-Module $moduleName
+        $module | Should -Be $true
+    }
+
+    It ('passes Test-ModuleManifest') {
+        Test-ModuleManifest -Path:("$PSScriptRoot/../$moduleName.psd1") | Should -Not -BeNullOrEmpty
+        $? | Should -Be $true
+    }
+}

--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -1,0 +1,53 @@
+---
+name: Module CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.psm1'
+      - '**.psd1'
+
+jobs:
+  test-pwshcore-linux:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run Pester Tests (pwsh)
+      run: |
+        Write-Output $PSVersionTable.PSVersion.Major $PSVersionTable.PSRemotingProtocolVersion.Minor
+        Set-PSRepository psgallery -InstallationPolicy trusted
+        Install-Module -Name Pester -confirm:$false -Force
+        Invoke-Pester -Path "./.ci/pester.tests.ps1" -EnableExit
+      shell: pwsh
+
+  # test-pwshcore-windows:
+  #   strategy:
+  #     matrix:
+  #       platform: [windows-latest]
+  #   runs-on: ${{ matrix.platform }}
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Run Pester Tests (pwsh)
+  #     run: |
+  #       Write-Output $PSVersionTable.PSVersion.Major $PSVersionTable.PSRemotingProtocolVersion.Minor
+  #       Set-PSRepository psgallery -InstallationPolicy trusted
+  #       Install-Module -Name Pester -confirm:$false -Force
+  #       Invoke-Pester -Path "./.ci/pester.test.ps1" -EnableExit
+  #     shell: pwsh
+  
+  # test-powershell-windows:
+  #   runs-on: windows-latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Run Pester Tests (Windows PowerShell)
+  #     run: |
+  #       Write-Output $PSVersionTable.PSVersion.Major $PSVersionTable.PSRemotingProtocolVersion.Minor
+  #       Set-PSRepository psgallery -InstallationPolicy trusted
+  #       Install-Module -Name Pester -Confirm:$false -Force
+  #       Invoke-Pester -Path "./.ci/pester.tests.ps1" -EnableExit
+  #       if ($Error[0].Fullyqualifiederrorid -eq 'PesterAssertionFailed') {exit 1}        
+  #     shell: powershell


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/power-validated-solutions-for-cloud-foundation/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

<!--
    Please provide a clear and concise description of the pull request.
-->

Adds **basic** CI checks for module import and manifest check when changed are made to .`psm1` and `.psd1` files only.

> **Note**
>
> 1. **GHA**: Windows matrix is disabled for now in the action.
> 2. **Pester**: Can be extended to run mock tests, if desired.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [x] This is something else.
      Please describe: `ci`

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
