### PR TITLE
Add Shared Functions for vSphere Distributed port group and New Add License for Site Recovery Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 - Enhanced `Install-SiteRecoveryManager` cmdlet to support an alternative path to the OVF Tool -vmwareOvfToolPath, and code improvements.
 - Enhanced `Install-vSphereReplicationManager` cmdlet to support an alternative path to the OVF Tool -vmwareOvfToolPath and code improvements.
 - Enhanced `Connect-DRSolutionTovCenter` cmdlet to support registration with any vCenter Server and code improvements.
+- Added `Add-VrmsNetworkAdapter` cmdlet to support adding a second nic to vSphere Replication.
+- Added `Add-SrmLicenseKey` cmdlet to support adding and assigning a Site Recovery Manager license.
+- Added `Undo-SrmLicenseKey` cmdlet to support removing a Site Recovery license.
+- Added `Add-VdsPortGroup` cmdlet to support creating a vSphere Distributed Switch port group and assigning a VLAN id.
+- Added `Undo-VdsPortGroup` cmdlet to support removing a vSphere Distributed Switch port group.
 
 ## v1.9.0 (2022-25-10)
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.10.0.1000'
+    ModuleVersion = '1.10.0.1001'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/power-validated-solutions-for-cloud-foundation/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

- Added Add-VdsPortGroup to create a vSphere Distributed port group
- Added Undo-VdsPortGroup to remove vSphere Distributed port group
- Added Add-VrmsNetworkAdapter to create a new adapter in vSphere Replication
- Added Add-SrmLicenseKey to add a license to single vCenter/Site Recovery Manager
- Added Undo-SrmLicenseKey to remove a license to single vCenter/Site Recovery Manager

Signed-off-by: Gary Blake <gblake@vmware.com>

**Type of Pull Request**

- [ ] This is a bug fix.
- [x] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.

**Related to Existing Issues**

Issue Number:
- Closes #156 
- Closes #157 

**Test and Documentation Coverage**

- [x] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.