### PR TITLE
feat(pdr): Add ESXi Static Route Flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,10 @@
 - Added `Set-SrmVamiCertificate` cmdlet to install a new certificate for the VAMI interface of a Site Recovery Manager appliance.
 - Added `Undo-SiteRecoveryManager` to remove the Site Recovery Manager virtual appliance.
 - Added `Undo-vSphereReplicationManager` to remove the vSphere Replication virtual appliance.
-- Added `Add-EsxiVMkernelPort` cmdlet to create ESXi VMKernel port for vSphere Replication Traffic.
-- Added `Undo-EsxiVMkernelPort` cmdlet to remove ESXi VMKernel port for vSphere Replication Traffic.
+- Added `Add-EsxiVMkernelPort` cmdlet to create ESXi VMKernel port for vSphere Replication Traffic flexibility.
+- Added `Undo-EsxiVMkernelPort` cmdlet to remove ESXi VMKernel port for vSphere Replication Traffic flexibility.
+- Added `Add-EsxiVrmsStaticRoute` cmdlet to provide ESXi static route configuration flexibility.
+- Added `Undo-EsxiVrmsStaticRoute` cmdlet to provide ESXi static route removal flexibility.
 
 ## v1.9.0 (2022-25-10)
 

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.10.0.1002'
+    ModuleVersion = '1.10.0.1003'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/power-validated-solutions-for-cloud-foundation/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

- Added `Add-EsxiVrmsStaticRoute` cmdlet to provide ESXi static route configuration flexibility
- Added `Undo-EsxiVrmsStaticRoute` cmdlet to provide ESXi static route removal flexibility
- Moved `Undo-EsxiVrmsStaticRoute` cmdlet to Deprecated Functions Region
- Moved `New-vSREsxiStaticRoute` cmdlet to Deprecated Functions Region

Signed-off-by: Gary Blake <gblake@vmware.com>

**Type of Pull Request**

- [ ] This is a bug fix.
- [x] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.

**Related to Existing Issues**

Issue Number: Closes #168 

**Test and Documentation Coverage**

- [x] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.
