### PR TITLE
refactor: global permissions for isolated workload domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v2.3.0 (Not Released)
 
+- **Breaking Change** - Updated `Add-vCenterGlobalPermission` cmdlet to require the `-sddcDomain` parameter to support isolated workload domains.
+- **Breaking Change** - Updated `Undo-vCenterGlobalPermission` cmdlet to require the `-sddcDomain` parameter to support isolated workload domains.
 - Fixed `New-vROPSDeployment` license check in vRealize Suite Lifecycle Manager locker.
 - Fixed `New-vRADeployment` license check in vRealize Suite Lifecycle Manager locker.
 - Enhanced `Export-vRLIJsonSpec` with a new switch to define a custom version of vRealize Log Insight to deploy.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.3.0.1002'
+    ModuleVersion = '2.3.0.1003'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/power-validated-solutions-for-cloud-foundation/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

<!--
    Please provide a clear and concise description of the pull request.
-->

- **Breaking Change** - Updated `Add-vCenterGlobalPermission` cmdlet to require the `-sddcDomain` parameter to support isolated workload domains.
- **Breaking Change** - Updated `Undo-vCenterGlobalPermission` cmdlet to require the `-sddcDomain` parameter to support isolated workload domains.
- Updated the module version from v2.3.0.1002 to v2.3.0.1003.
- Updated the `CHANGELOG.md`.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [x] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Context of the Pull Request***

<!--
    Please describe the current behavior that you are modifying or link to a relevant issue.
-->

Support for isolated workload domains.

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Closes #217

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

```powershell
PS F:\Local-GitHub> Undo-vCenterGlobalPermission -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -sddcDomain sfo-m01 -domain sfo.rainpole.io -principal gg-vc-admins -type group
Removing Global Permissions for group (gg-vc-admins) in vCenter Server (sfo-m01-vc01) and vCenter Single Sign-On domain (vsphere.local): SUCCESSFUL

PS F:\Local-GitHub> Add-vCenterGlobalPermission -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -sddcDomain sfo-m01 -domain sfo.rainpole.io -domainBindUser svc-vsphere-ad -domainBindPass VMw@re1! -principal gg-vc-admins -role Admin -propagate true -type group
Adding Global Permissions for group (gg-vc-admins) with role (Admin) in vCenter Server (sfo-m01-vc01) and vCenter Single Sign-On domain (vsphere.local): SUCCESSFUL

PS F:\Local-GitHub> Undo-vCenterGlobalPermission -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -sddcDomain sfo-m01 -domain sfo.rainpole.io -principal gg-vc-admins -type group
Removing Global Permissions for group (gg-vc-admins) in vCenter Server (sfo-m01-vc01) and vCenter Single Sign-On domain (vsphere.local): SUCCESSFUL

PS F:\Local-GitHub> Add-vCenterGlobalPermission -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -sddcDomain sfo-m01 -domain sfo.rainpole.io -domainBindUser svc-vsphere-ad -domainBindPass VMw@re1! -principal gg-vc-admins -role Admin -propagate true -type group
Adding Global Permissions for group (gg-vc-admins) with role (Admin) in vCenter Server (sfo-m01-vc01) and vCenter Single Sign-On domain (vsphere.local): SUCCESSFUL

PS F:\Local-GitHub> Add-vCenterGlobalPermission -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -sddcDomain sfo-w01 -domain sfo.rainpole.io -domainBindUser svc-vsphere-ad -domainBindPass VMw@re1! -principal gg-vc-admins -role Admin -propagate true -type group
WARNING: Adding Global Permission with Role (Admin) in vCenter Server (sfo-w01-vc01) to group (gg-vc-admins), already applied: SKIPPED

PS F:\Local-GitHub> Undo-vCenterGlobalPermission -server sfo-vcf01.sfo.rainpole.io -user administrator@vsphere.local -pass VMw@re1! -sddcDomain sfo-w01 -domain sfo.rainpole.io -principal gg-vc-admins -type group
Removing Global Permissions for group (gg-vc-admins) in vCenter Server (sfo-w01-vc01) and vCenter Single Sign-On domain (sfo-w01.local): SUCCESSFUL
```

- [x] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
