### PR TITLE
fix: address missing sso domain for pre 4.5.0.0 release of VCF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Breaking Change** - Updated `Undo-vCenterGlobalPermission` cmdlet to require the `-sddcDomain` parameter to support isolated workload domains.
 - Fixed `New-vROPSDeployment` license check in vRealize Suite Lifecycle Manager locker.
 - Fixed `New-vRADeployment` license check in vRealize Suite Lifecycle Manager locker.
+- Fixed `Get-vCenterServerDetail` which had blank SSO Domain for pre-VMware Cloud Foundation 4.5.0.0 release causing `Add-SsoPermission` to fail.
 - Enhanced `Export-vRLIJsonSpec` with a new switch to define a custom version of vRealize Log Insight to deploy.
 - Enhanced `New-vRLIDeployment` with a new switch to define a custom version of vRealize Log Insight to deploy.
 - Enhanced `Export-vROPSJsonSpec` with a new switch to define a custom version of vRealize Operations to deploy.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.3.0.1005'
+    ModuleVersion = '2.3.0.1006'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -13389,7 +13389,7 @@ Function Add-SsoPermission {
                                             if (!(Get-SsoGroup -Group $targetGroup -Name $principal -Server $ssoConnectionDetail)) {
                                                 $ldapGroup = Get-SsoGroup -Domain $domain -Name $principal -Server $ssoConnectionDetail
                                                 $ldapGroup | Add-GroupToSsoGroup -TargetGroup $targetGroup -ErrorAction SilentlyContinue
-                                                if (Get-SsoGroup $targetGroup -Name $principal -Server $ssoConnectionDetail) {
+                                                if (Get-SsoGroup -Group $targetGroup -Name $principal -Server $ssoConnectionDetail) {
                                                     Write-Output "Assigning SSO Group ($ssoGroup) in vCenter Server ($($vcfVcenterDetails.vmName)) to $type ($principal) for domain ($domain): SUCCESSFUL"
                                                 } else {
                                                     Write-Error "Assigning SSO On Group ($ssoGroup) in vCenter Server ($($vcfVcenterDetails.vmName)) to $type ($principal) for domain ($domain): POST_VALIDATION_FAILED"


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware-samples/power-validated-solutions-for-cloud-foundation/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

- Fixed `Get-vCenterServerDetail` which had blank SSO Domain for pre-VMware Cloud Foundation 4.5.0.0 release causing `Add-SsoPermission` to fail.
- Updated CHANGELOG.md
- Bumped the version in PowerValidatedSolutions.psd1 from `2.3.0.1005` to `2.3.0.1006`

**Type of Pull Request**

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

Issue Number: N/A

**Test and Documentation Coverage**

- [x] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.
