### PR TITLE
fix: address version check in vrli autentication functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 > Release Date: Unreleased
 
 - **Breaking Change** Fixed `Request-vRLIToken` to use new bearer token request for vRealize Log Insight.
+- Fixed `Add-vRLIAuthenticationGroup` cmdlet to check the vRealize Log Insight version correctly.
+- Fixed `Get-vRLIGroup` cmdlet to check the vRealize Log Insight version correctly.
+- Fixed `Add-vRLIGroup` cmdlet to check the vRealize Log Insight version correctly.
+- Fixed `Remove-vRLIGroup` cmdlet to check the vRealize Log Insight version correctly.
 - Added `Test-EndpointConnection` cmdlet to test the connectivity to an endpoint based on PowerShell edition.
 - Added `Test-EsxiConnection` cmdlet to use `Test-EndpointConnection` with TCP 443 (HTTPS) and TCP 22 (SSH). Default: TCP 443 (HTTPS).
 - Added `Test-EsxiAuthentication` cmdlet to test the authentication to an ESXi host.

--- a/PowerValidatedSolutions.psd1
+++ b/PowerValidatedSolutions.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PowerValidatedSolutions.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.5.0.1006'
+    ModuleVersion = '2.5.0.1007'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -8205,7 +8205,7 @@ Function Add-vRLIAuthenticationGroup {
                     if (Test-vRLIConnection -server $vcfVrliDetails.fqdn) {
                         if (Test-vRLIAuthentication -server $vcfVrliDetails.fqdn -user $vcfVrliDetails.adminUser -pass $vcfVrliDetails.adminPass) {
                             if ((Get-vRLIAuthenticationWSA).enabled -eq "True") {
-                                if ((Get-vRLIVersion).version.Split("-")[0] -lt "8.6.2") {
+                                if ((Get-vRLIVersion).version.Split("-")[0] -lt 8.6.2) {
                                     if (!(Get-vRLIGroup -authProvider vidm | Where-Object {$_.name -eq $group + "@" + $domain})) {
                                         Add-vRLIGroup -authProvider vidm -domain $domain -group $group -role $role | Out-Null
                                         if (Get-vRLIGroup -authProvider vidm | Where-Object {$_.name -eq $group + "@" + $domain}) {
@@ -29508,7 +29508,7 @@ Function Get-vRLIGroup {
     )
 
     Try {
-        if ((Get-vRLIVersion).version.Split("-")[0] -lt "8.6.2") {
+        if ((Get-vRLIVersion).version.Split("-")[0] -lt 8.6.2) {
             $uri = "https://$vrliAppliance/api/v1/authgroups/$authProvider"
             $response = Invoke-RestMethod -Method 'GET' -Uri $uri -Headers $vrliHeaders
             $response.authProviderGroups
@@ -29543,7 +29543,7 @@ Function Add-vRLIGroup {
     )
 
     Try {
-        if ((Get-vRLIVersion).version.Split("-")[0] -lt "8.6.2") {
+        if ((Get-vRLIVersion).version.Split("-")[0] -lt 8.6.2) {
             $roleId = (Get-vRLIRole | Where-Object {$_.name -eq $role}).id
             $uri = "https://$vrliAppliance/api/v1/authgroups"
             $json = '{ "provider": "' + $authProvider + '", "domain": "'+ $domain +'", "name": "'+ $group + "@" + $domain +'", "groupIds": [ "'+ $roleId + '" ]}'
@@ -29578,7 +29578,7 @@ Function Remove-vRLIGroup {
     )
 
     Try {
-        if ((Get-vRLIVersion).version.Split("-")[0] -lt "8.6.2") {
+        if ((Get-vRLIVersion).version.Split("-")[0] -lt 8.6.2) {
             $uri = "https://$vrliAppliance/api/v1/authgroups/$authProvider/$domain/$group@$domain"
             $response = Invoke-RestMethod -Method 'DELETE' -Uri $uri -Headers $vrliHeaders
             $response


### PR DESCRIPTION
### Summary

- Fixed `Add-vRLIAuthenticationGroup` cmdlet to check the vRealize Log Insight version correctly.
- Fixed `Get-vRLIGroup` cmdlet to check the vRealize Log Insight version correctly.
- Fixed `Add-vRLIGroup` cmdlet to check the vRealize Log Insight version correctly.
- Fixed `Remove-vRLIGroup` cmdlet to check the vRealize Log Insight version correctly.

### Type

- [ ] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [ ] No, there are no breaking changes.

### Test and Documentation

- [ ] Tests have been completed.
- [ ] Documentation has been added or updated.

### Issue References

Closes #223 

### Additional Information
